### PR TITLE
fix(windows): route npm through cmd.exe so the source install works

### DIFF
--- a/cabinetai/src/lib/app-manager.ts
+++ b/cabinetai/src/lib/app-manager.ts
@@ -13,7 +13,7 @@ import {
   validateVersion,
 } from "./paths.js";
 import { log, success, warning } from "./log.js";
-import { npmCommand } from "./process.js";
+import { runNpm, describeSpawnFailure } from "./process.js";
 import { fetchReleaseManifest, resolveAppBundle, type ReleaseAppBundle } from "./release-manifest.js";
 
 const REPO_URL = "https://github.com/cabinetai/cabinet";
@@ -210,12 +210,9 @@ async function installFromSource(version: string, appDir: string): Promise<void>
 
   if (!fs.existsSync(path.join(appDir, "node_modules", "next"))) {
     log("Installing dependencies...");
-    const result = spawnSync(npmCommand(), ["install"], {
-      cwd: appDir,
-      stdio: "inherit",
-    });
-    if (result.status !== 0) {
-      throw new Error("Failed to install dependencies");
+    const result = runNpm(["install"], { cwd: appDir });
+    if (result.error || result.status !== 0) {
+      throw new Error(`Failed to install dependencies: ${describeSpawnFailure(result)}`);
     }
   }
 

--- a/cabinetai/src/lib/health-checks.ts
+++ b/cabinetai/src/lib/health-checks.ts
@@ -1,9 +1,9 @@
 import fs from "fs";
 import path from "path";
-import { spawnSync } from "child_process";
 import { findCabinetRoot } from "./paths.js";
 import { appVersionDir } from "./paths.js";
-import { npmCommand } from "./process.js";
+import { runNpm, describeSpawnFailure } from "./process.js";
+import { warning } from "./log.js";
 import { isPortFree, parsePort } from "./ports.js";
 
 export interface CheckResult {
@@ -81,7 +81,10 @@ export function checkAppDeps(version: string): CheckResult {
       status: "fail",
       message: "Dependencies not installed.",
       fix: () => {
-        spawnSync(npmCommand(), ["install"], { cwd: appDir, stdio: "inherit" });
+        const result = runNpm(["install"], { cwd: appDir });
+        if (result.error || result.status !== 0) {
+          warning(`npm install failed: ${describeSpawnFailure(result)}`);
+        }
       },
     };
   }

--- a/cabinetai/src/lib/process.test.ts
+++ b/cabinetai/src/lib/process.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { npmCommand, runNpm, describeSpawnFailure } from "./process.js";
+
+// Regression test for the Windows dependency-install failure.
+//
+// `npm install` used to be invoked as spawnSync(npmCommand(), ["install"])
+// with no shell. On win32 npmCommand() is "npm.cmd", and since the Node
+// hardening released for CVE-2024-27980 spawning a .cmd without a shell fails
+// with EINVAL — so `npx cabinetai run` could never install the app's
+// dependencies on Windows.
+//
+// `--version` stands in for `install` here: it exercises the same spawn path
+// (the part that was broken) in well under a second and writes nothing to
+// disk.
+//
+// Note this test can only *fail* on win32. On macOS and Linux npm was always
+// spawned directly and passed both before and after the fix, which is exactly
+// the platform split of the bug.
+
+test("runNpm can actually start npm on this platform", () => {
+  const result = runNpm(["--version"], { stdio: "pipe" });
+
+  assert.equal(
+    result.error,
+    undefined,
+    `npm could not be spawned: ${describeSpawnFailure(result)}`
+  );
+  assert.equal(result.status, 0, describeSpawnFailure(result));
+  assert.match(result.stdout.toString().trim(), /^\d+\.\d+\.\d+/);
+});
+
+test("describeSpawnFailure surfaces the underlying spawn error", () => {
+  const result = spawnSync("cabinet-nonexistent-binary-xyz", ["--version"]);
+
+  assert.ok(result.error, "expected the bogus binary to fail to spawn");
+  assert.match(describeSpawnFailure(result), /ENOENT/);
+});
+
+test("npmCommand targets npm.cmd on win32 only", () => {
+  assert.equal(npmCommand(), process.platform === "win32" ? "npm.cmd" : "npm");
+});

--- a/cabinetai/src/lib/process.ts
+++ b/cabinetai/src/lib/process.ts
@@ -1,8 +1,49 @@
-import { spawnSync, spawn, type ChildProcess, type SpawnOptions } from "child_process";
+import {
+  spawnSync,
+  spawn,
+  type ChildProcess,
+  type SpawnOptions,
+  type SpawnSyncOptions,
+  type SpawnSyncReturns,
+} from "child_process";
 import { error } from "./log.js";
 
 export function npmCommand(): string {
   return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+/**
+ * Run an npm subcommand synchronously.
+ *
+ * On Windows npm's entry point is `npm.cmd`, a batch file. Since the Node
+ * hardening released for CVE-2024-27980, spawning a `.cmd` without a shell
+ * fails with EINVAL, so npm has to be reached through the command interpreter.
+ *
+ * We do that by spawning `cmd.exe /c npm.cmd <args>` with a real argument
+ * array rather than passing `shell: true`. With `shell: true` Node
+ * concatenates the arguments into a single unescaped command string, which
+ * Node warns about (DEP0190). An argument array is quoted by Node before
+ * cmd.exe re-parses it.
+ */
+export function runNpm(args: string[], opts: SpawnSyncOptions = {}): SpawnSyncReturns<Buffer> {
+  const options: SpawnSyncOptions = { stdio: "inherit", ...opts };
+  const result =
+    process.platform === "win32"
+      ? spawnSync("cmd.exe", ["/c", npmCommand(), ...args], options)
+      : spawnSync(npmCommand(), args, options);
+  return result as SpawnSyncReturns<Buffer>;
+}
+
+/**
+ * Describe why a spawnSync call failed, so callers can report the underlying
+ * cause instead of collapsing every failure into one generic message.
+ */
+export function describeSpawnFailure(result: SpawnSyncReturns<Buffer>): string {
+  if (result.error) return result.error.message;
+  const stderr = result.stderr ? result.stderr.toString().trim() : "";
+  if (stderr) return stderr;
+  if (result.signal) return `terminated by signal ${result.signal}`;
+  return `exited with code ${result.status}`;
 }
 
 export function run(bin: string, args: string[], opts: Record<string, unknown> = {}): void {


### PR DESCRIPTION
Windows users cannot get past the dependency install. `npx cabinetai run` prints `Failed to install dependencies` with no cause.

I have a Windows 11 machine, so I ran the smoke test from `docs/WINDOWS_PR139_SMOKE_TEST.md` against `main` at 92ed8a6. "Fresh `cabinetai run` cannot reach a working app URL" is on that guide's own blocking list, and it still fails.

## Cause

`npmCommand()` returns `npm.cmd` on win32, and both call sites spawned it with `spawnSync` and no shell.

Since the hardening released for CVE-2024-27980, Node errors with `EINVAL` when a `.bat` or `.cmd` is passed to `spawn` or `spawnSync` without the `shell` option:

> Node.js will now error with `EINVAL` if a `.bat` or `.cmd` file is passed to `child_process.spawn` and `child_process.spawnSync` without the `shell` option set.

Released 2024-04-10 in v18.20.2, v20.12.2 and v21.7.3, and present from v22.0.0 onward. It cannot be turned off any more, since the `--security-revert` flag was removed.

So npm never starts. Only `result.status` was checked, so `result.error` was dropped and the real failure never reached the user.

Windows always reaches this path when an install is actually needed: `getAppBundleKey()` in `release-manifest.ts` has no `win32` case, so the CLI logs `No prebuilt bundle for win32/x64; using source install`.

## Scope

Windows users on a fresh install or a version upgrade, running a Node version that carries the hardening. Anyone whose `node_modules/next` already exists skips the step and never sees it.

## The change

One `runNpm()` helper. On win32 it spawns `cmd.exe /c`, which is the invocation Node's own `child_process` docs list for `.bat` and `.cmd` files and what `exec()` does internally. Elsewhere it spawns npm directly, so the posix path is expression-identical to what it replaced.

`shell: true` also makes the error go away, but DEP0190 is a runtime deprecation for exactly that shape: with an args array the values are not escaped, only concatenated. Using it would print a deprecation warning to users on every install.

Both call sites now surface the real error rather than collapsing it to a status check.

## Tests

`process.test.ts` fails before and passes after on win32. Existing suite 8/8, `tsc --noEmit` clean, `npm run build` clean.

End to end on Windows 11, Node v24.12.0, npm 11.6.2, with an isolated `USERPROFILE`:

- unpatched: `Failed to install dependencies`
- patched: `added 1622 packages` then `Cabinet v0.5.3 installed.` then `Ready in 4.9s`

`cabinetai doctor --fix` is the second call site. Unpatched it prints `Fixing...`, then silently does nothing and creates no lockfile. Patched it runs npm and creates it.

## Notes

- Related: #80 bug 3 and #97 are the same symptom. Neither identified the cause, and there is no mention of `EINVAL` or `npm.cmd` anywhere in the tracker.
- `app-manager.ts` already does `result.error || result.status !== 0` for the tar call, so this makes npm consistent with tar rather than introducing a new pattern.
- Not run on macOS or Linux. The posix branch is expression-identical to the code it replaces and only the error text changed.
- Possible follow-up, not included here: `spawnSync("cmd.exe", ...)` resolves through PATH rather than `process.env.ComSpec`.
- Also spotted and deliberately out of scope: `openBrowser` uses `start` on win32, which is a cmd builtin rather than an executable, so `--open` returns ENOENT and silently does nothing.