### PR TITLE
fix(agents): point four recommendedSkills at their renamed upstream skills

### DIFF
--- a/src/lib/agents/library/content-marketer/persona.md
+++ b/src/lib/agents/library/content-marketer/persona.md
@@ -14,8 +14,8 @@ workspace: /marketing
 recommendedSkills:
   - key: content-strategy
     source: github:coreyhaines31/marketingskills/content-strategy
-  - key: social-content
-    source: github:coreyhaines31/marketingskills/social-content
+  - key: social
+    source: github:coreyhaines31/marketingskills/social
 channels:
   - general
   - marketing

--- a/src/lib/agents/library/growth-marketer/persona.md
+++ b/src/lib/agents/library/growth-marketer/persona.md
@@ -14,8 +14,8 @@ workspace: /marketing/growth
 recommendedSkills:
   - key: marketing-ideas
     source: github:coreyhaines31/marketingskills/marketing-ideas
-  - key: launch-strategy
-    source: github:coreyhaines31/marketingskills/launch-strategy
+  - key: launch
+    source: github:coreyhaines31/marketingskills/launch
 canDispatch: true
 ---
 

--- a/src/lib/agents/library/post-optimizer/persona.md
+++ b/src/lib/agents/library/post-optimizer/persona.md
@@ -12,8 +12,8 @@ active: true
 workdir: /data
 workspace: /cabinet-example
 recommendedSkills:
-  - key: page-cro
-    source: github:coreyhaines31/marketingskills/page-cro
+  - key: cro
+    source: github:coreyhaines31/marketingskills/cro
 channels:
   - general
   - content

--- a/src/lib/agents/library/social-media/persona.md
+++ b/src/lib/agents/library/social-media/persona.md
@@ -12,8 +12,8 @@ active: true
 workdir: /data
 workspace: /marketing/social
 recommendedSkills:
-  - key: social-content
-    source: github:coreyhaines31/marketingskills/social-content
+  - key: social
+    source: github:coreyhaines31/marketingskills/social
 canDispatch: true
 ---
 


### PR DESCRIPTION
Four `recommendedSkills` entries in the agent library point at skill folders that no longer exist upstream, so **Install and attach** fails with `skill "social-content" not found in coreyhaines31/marketingskills`.

Not a Cabinet bug. The names moved upstream.

## What happened

`coreyhaines31/marketingskills` renamed them on 2026-05-14 in `30f9b9a7`, *"feat: v2.0 skill renames and CRO consolidation (#291)"*. That commit is both the last one touching `skills/social-content` and the only one creating `skills/cro`.

| Template | Old key | New |
|---|---|---|
| `content-marketer` | `social-content` | `social` |
| `social-media` | `social-content` | `social` |
| `growth-marketer` | `launch-strategy` | `launch` |
| `post-optimizer` | `page-cro` | `cro` |

Checked against the repo just now: `social-content`, `launch-strategy` and `page-cro` all return 404, and `social`, `launch` and `cro` all return 200.

## Why both lines move

Each entry carries a `key` and a `source`. The key is matched against the catalog, the source feeds the installer, and the import route names the installed bundle after the last path segment of the source. Changing only the source would install the right skill and still show the suggestion as unmet.

## How this was found

I ran every one of the 19 shipped `recommendedSkills` entries through a port of the import route's own resolution ladder: direct path, then `skills/<name>`, then `.claude-plugin/plugin.json`, then the recursive walk. 14 resolve, these 4 do not, and `shadcn` on `cto` is a bare key with no source, which looks deliberate.

The failure is user-visible rather than theoretical: `agent-detail-v2.tsx` renders an Install and attach button for any recommendation carrying a `source`.

## Note

All three replacements come from the same repo whose rename caused this, so the same thing can happen again. A periodic check of the 19 entries would catch it, and the resolution-ladder script that found this is easy to share if that is useful.